### PR TITLE
fix nils: support for nil values

### DIFF
--- a/lib/rails-csv-fixtures/active_record_csv_fixtures.rb
+++ b/lib/rails-csv-fixtures/active_record_csv_fixtures.rb
@@ -23,7 +23,7 @@ module RailsCsvFixtures
       i = 0
       reader.each do |row|
         data = {}
-        row.each_with_index { |cell, j| data[header[j].to_s.strip] = cell.to_s.strip }
+	row.each_with_index { |cell, j| data[header[j].to_s.strip] = cell.nil? ? nil : cell.to_s.strip }
         fixtures["#{@class_name.to_s.underscore}_#{i+=1}"] = ActiveRecord::Fixture.new(data, model_class)
       end
     end


### PR DESCRIPTION
Hi,

I modified the plugin to support null values.
Previous state: both no-value(e.g. a,,c) and ""(e.g. a,"",c ) were treated as empty string
Fix: no-value is treated as nil, and "" is treated as empty string

I reused the "is_nil" method at the CSV::Cell class.

related reference
http://www.ruby-forum.com/topic/209308

Cheers,
Nitzan
Israel
